### PR TITLE
Fixed and cleaned up mage/priest leadership

### DIFF
--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -526,72 +526,53 @@ public class MageGenerator extends TroopGenerator {
 
 		
 		// Extra mage
-		boolean ok = false;
 		int checks = 0;
 		
-		if(diversity < 3 && ((norand_picks.get(MagicPath.ASTRAL) == 0 && norand_picks.get(MagicPath.BLOOD) == 0) && this.random.nextDouble() < 0.8))
+		//guaranteed astral or blood access forfeits most extra mage chances
+		if (norand_picks.get(MagicPath.ASTRAL) == 0 && norand_picks.get(MagicPath.BLOOD) == 0)
 		{
-			ok = true;
-			checks++;
-		}
-		
-		if(max < 4 && norand_picks.get(MagicPath.ASTRAL) == 0 && norand_picks.get(MagicPath.BLOOD) == 0 && diversity < 3)
-		{
-			ok = true;
-			checks++;
-		}
-		
-		if(diversity < 4 && norand_picks.get(MagicPath.ASTRAL) == 0 && norand_picks.get(MagicPath.BLOOD) == 0 && this.random.nextDouble() < 0.5)
-		{
-			ok = true;
-			checks++;
-		}
-		else if(diversity < 4 && norand_picks.get(MagicPath.ASTRAL) == 0 && norand_picks.get(MagicPath.BLOOD) == 0 && norand_picks.get(MagicPath.EARTH) == 0 && norand_picks.get(MagicPath.FIRE) == 0 && this.random.nextDouble() < 0.2)
-		{
-			ok = true;
-			checks++;
-		}
-		
-		
-		if(max < 4 && atmax < 2 && picks.get(MagicPath.ASTRAL) == 0 && picks.get(MagicPath.BLOOD) == 0 && this.random.nextDouble() < 0.5)
-		{
-			ok = true;
-			checks++;
-		}
-		else if(max < 3 && atmax < 4 && picks.get(MagicPath.ASTRAL) == 0 && picks.get(MagicPath.BLOOD) == 0)
-		{
-			ok = true;
-			checks++;
-		}
-		
-		if(norand_picks.get(MagicPath.ASTRAL) == 0 && norand_picks.get(MagicPath.BLOOD) == 0 && diversity < 4 && this.random.nextDouble() < 0.2)
-		{
-			ok = true;
-			checks++;
-		}
-		if(norand_picks.get(MagicPath.ASTRAL) == 0 && norand_picks.get(MagicPath.BLOOD) == 0 && atmax == 1 && diversity < 2 && this.random.nextDouble() < 0.8)
-		{
-			ok = true;
-			checks++;
-		}
-		if(norand_picks.get(MagicPath.ASTRAL) < 2 && norand_picks.get(MagicPath.BLOOD) < 2 && atmax == 1 && diversity < 2 && this.random.nextDouble() < 0.5)
-		{
-			ok = true;
-			checks++;
-		}
-		
-		if(primaries == 1 && secondaries == 1 && !(norand_picks.get(MagicPath.ASTRAL) > 0 || norand_picks.get(MagicPath.BLOOD) > 0))
-		{
-			if((checks == 0 && random.nextDouble() < 0.7) || (checks == 1 && random.nextDouble() < 0.3))
-			{	
-				ok = true;
-				checks++;
-			}
-		}
+			if(diversity < 4)
+			{
+				if (diversity < 3)
+				{
+					if (max < 4)
+						checks++;
 				
+					if (this.random.nextDouble() < 0.8)
+						checks++;
+	
+					if (diversity < 2 && atmax == 1 && this.random.nextDouble() < 0.8)
+						checks++;
+				}
+	
+				//there used to be an extra 1 in 10 chance for mage lists without guaranteed earth 1 or fire 1 - this seemed very arbitrary and fiddly so I did away with the restriction
+				if (this.random.nextDouble() < 0.6)
+					checks++;
+	
+				if (this.random.nextDouble() < 0.2)
+					checks++;
+			}
+
+			//random astral/blood is still eligible for most checks, but nations without get a few extra chances
+			if (picks.get(MagicPath.ASTRAL) == 0 && picks.get(MagicPath.BLOOD) == 0)
+			{
+				if(max < 3 && atmax < 4)
+					checks++;
+				else if(max < 4 && atmax < 2 && this.random.nextDouble() < 0.5)
+					checks++;
+			}
+
+			if (primaries == 1 && secondaries == 1 && this.random.nextDouble() < (0.7 - 0.4 * checks)) 
+				//random freebie: likely for 0 checks, unlikely for 1 check, impossible for 2+
+				checks++;
+		}
+		else if(norand_picks.get(MagicPath.ASTRAL) < 2 && norand_picks.get(MagicPath.BLOOD) < 2 && atmax == 1 && diversity < 2 && this.random.nextDouble() < 0.5) 
+			//weak astral/blood can still get a shot if diversity is really bad
+			checks++;				
+
 		List<Unit> extramages = new ArrayList<Unit>();
 		
-		if(ok)
+		if(checks > 0)
 		{
 			extramages = this.generateExtraMages(primaries, this.getShuffledPrios(list), checks);
 			this.resolveAge(extramages);

--- a/src/nationGen/magic/MageGenerator.java
+++ b/src/nationGen/magic/MageGenerator.java
@@ -399,8 +399,6 @@ public class MageGenerator extends TroopGenerator {
 		all.add(secondarypatterns);
 		all.add(primarypatterns);
 		
-		double leaderrandom1 = this.random.nextDouble();
-		double leaderrandom2 = this.random.nextDouble();
 		double slowrecrand = this.random.nextDouble();
 		
 	
@@ -434,83 +432,8 @@ public class MageGenerator extends TroopGenerator {
 				// Sets mage name to match pattern. Debug purposes.
 				mages.get(i).get(j).name.setType(all.get(i).get(j).toString(derp));
 				
-			
-				if(mages.get(i).get(j).tags.containsName("warriormage"))
-				{
-					if(leaderrandom1 > 0.95)
-					{
-						mages.get(i).get(j).commands.add(new Command("#expertleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+50"));
-					}
-					else if(leaderrandom1 > 0.8 || mages.get(i).get(j).tags.containsName("#superior_leader"))
-					{
-						mages.get(i).get(j).commands.add(new Command("#goodleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+30"));
-					}
-					else if(leaderrandom1 > 0.5)
-					{
-						mages.get(i).get(j).commands.add(new Command("#okayleader"));
-						mages.get(i).get(j).commands.add(Command.args("#command", "+20"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+10"));
-					}
-					else if(leaderrandom1 > 0.25 || mages.get(i).get(j).tags.containsName("#good_leader"))
-					{
-						mages.get(i).get(j).commands.add(new Command("#okayleader"));
-					}
-					else if(leaderrandom1 > 0.0625)
-					{
-						mages.get(i).get(j).commands.add(new Command("#poorleader"));
-						mages.get(i).get(j).commands.add(Command.args("#command", "+30"));
-					}
-					else
-					{
-						mages.get(i).get(j).commands.add(new Command("#poorleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "-5"));
-					}
 
-				}
-					
-				else
-				{
-					if(mages.get(i).get(j).tags.containsName("#superior_leader") && leaderrandom1 > 0.9)
-					{
-						mages.get(i).get(j).commands.add(new Command("#expertleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+50"));
-					}
-					else if(mages.get(i).get(j).tags.containsName("#superior_leader") && leaderrandom1 > 0.6)
-					{
-						mages.get(i).get(j).commands.add(new Command("#goodleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+40"));
-					}
-					else if(mages.get(i).get(j).tags.containsName("#good_leader") && leaderrandom1 > 0.9)
-					{
-						mages.get(i).get(j).commands.add(new Command("#goodleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+40"));
-					}
-					else if(i == 2 && leaderrandom1 > 0.9)
-					{
-						mages.get(i).get(j).commands.add(new Command("#goodleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+40"));
-					}
-					else if(i == 2 && leaderrandom1 > 0.6)
-					{
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+20"));
-					}
-					else if(i == 1 && leaderrandom1 > 0.9 && leaderrandom2 > 0.5)
-					{
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+20"));
-					}
-					else if(leaderrandom2 > 0.3 || leaderrandom1 > 0.3 || i > 0)
-					{
-						mages.get(i).get(j).commands.add(new Command("#poorleader"));
-						mages.get(i).get(j).commands.add(Command.args("#gcost", "+5"));
-					}
-					else
-					{
-						mages.get(i).get(j).commands.add(new Command("#noleader"));
-					}
-				}
-
+				double leadership = randomizeLeadership(mages.get(i).get(j), 0, i+1);
 					
 					
 				// SETTING HERE FOR MAGE INSANITY
@@ -1420,151 +1343,18 @@ public class MageGenerator extends TroopGenerator {
 
 			}
 
-			if(u.tags.containsName("warriormage"))
-			{
-				double leaderrandom = r.nextDouble();
-				if(u.tags.containsName("superior_leader")) leaderrandom += 0.4;
-				if(u.tags.containsName("good_leader")) leaderrandom += 0.2;
-				
-				if(leaderrandom > 0.95)
-				{
-					u.commands.add(new Command("#expertleader"));
-					u.commands.add(Command.args("#gcost", "+80"));
-					currentRP = Integer.max(2, currentRP);
-				}
-				else if(leaderrandom > 0.9)
-				{
-					u.commands.add(new Command("#expertleader"));
-					u.commands.add(Command.args("#command", "-40"));
-					u.commands.add(Command.args("#gcost", "+50"));
-					currentRP = Integer.max(2, currentRP);
-				}
-				else if(leaderrandom > 0.75)
-				{
-					u.commands.add(new Command("#goodleader"));
-					u.commands.add(Command.args("#gcost", "+40"));
-					currentRP = Integer.max(2, currentRP);
-				}
-				else if(leaderrandom > 0.70)
-				{
-					u.commands.add(new Command("#goodleader"));
-					u.commands.add(Command.args("#command", "-40"));
-					u.commands.add(Command.args("#gcost", "+30"));
-					currentRP = Integer.max(2, currentRP);
-				}
-				else if(leaderrandom > 0.55)
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#command", "+20"));
-					u.commands.add(Command.args("#gcost", "+20"));
-				}
-				else if(leaderrandom > 0.20)
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#gcost", "+10"));
-				}
-				else if(leaderrandom > 0.0675)
-				{
-					u.commands.add(new Command("#poorleader"));
-					u.commands.add(Command.args("#command", "+30"));
-					u.commands.add(Command.args("#gcost", "+5"));
-				}
-				else
-				{
-					u.commands.add(new Command("#poorleader"));
-				}
-			}
-			else if(currentStrength == 3 && r.nextDouble() > 0.75)
-			{
-				double leaderrandom = r.nextDouble();
-				if(u.tags.containsName("superior_leader")) leaderrandom += 0.4;
-				if(u.tags.containsName("good_leader")) leaderrandom += 0.2;
-				
-				if(leaderrandom > 0.95)
-				{
-					u.commands.add(new Command("#expertleader"));
-					u.commands.add(Command.args("#gcost", "+80"));
-				}
-				else if(leaderrandom > 0.85)
-				{
-					u.commands.add(new Command("#goodleader"));
-					u.commands.add(Command.args("#gcost", "+40"));
-				}
-				else if(leaderrandom > 0.75)
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#command", "+40"));
-					u.commands.add(Command.args("#gcost", "+30"));
-				}
-				else
-				{
-					u.commands.add(new Command("#okayleader"));
-				}
-			}
-			else if(currentStrength == 2 && r.nextDouble() > 0.85){
-				double leaderrandom = r.nextDouble();
-				if(u.tags.containsName("superior_leader")) leaderrandom += 0.4;
-				if(u.tags.containsName("good_leader")) leaderrandom += 0.2;
-				if(leaderrandom > 0.95)
-				{
-					u.commands.add(new Command("#expertleader"));
-					u.commands.add(Command.args("#command", "-40"));
-					u.commands.add(Command.args("#gcost", "+60"));
-				}
-				else if(leaderrandom > 0.90)
-				{
-					u.commands.add(new Command("#goodleader"));
-					u.commands.add(Command.args("#gcost", "+40"));
-				}
-				else if(leaderrandom > 0.85)
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#command", "+40"));
-					u.commands.add(Command.args("#gcost", "+30"));
-				}
-				else if(leaderrandom > 0.75)
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#command", "+20"));
-					u.commands.add(Command.args("#gcost", "+20"));
-				}
-				else
-				{
-					u.commands.add(new Command("#okayleader"));
-				}
-			}
-			else
-			{
-				if(u.tags.containsName("superior_leader") || u.tags.containsName("good_leader"))
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#gcost", "+10"));
-				}
-				else if(maxStrength == 1 && r.nextDouble() > 0.5)
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#gcost", "+10"));
-				}
-				else if(currentStrength == 1 && r.nextDouble() > 0.875)
-				{
-					u.commands.add(new Command("#okayleader"));
-					u.commands.add(Command.args("#gcost", "+10"));
-				}
-				else if(currentStrength == 1 && maxStrength > 1 && r.nextDouble() > 0.875)
-				{
-					u.commands.add(new Command("#noleader"));
-					u.commands.add(Command.args("#gcost", "-5"));
-				}
-				else
-				{
-					u.commands.add(new Command("#poorleader"));
-					if(r.nextDouble() > 0.875)
-					{
-						u.commands.add(Command.args("#command", "+30"));
-						u.commands.add(Command.args("#gcost", "+5"));
-					}
-				}
-			}
+
+			double leaderBonus = 0;
+			double leadership = 0; 
+
+			// if there is only 1 tier of priest, give them a boost to leadership
+			if (maxStrength == 1)
+				leaderBonus = 0.4;
+
+			leadership = randomizeLeadership(u, leaderBonus, currentStrength);
+
+			if (leadership > 60)
+				currentRP = Math.max(2, currentRP);
 
 			currentRP = Integer.max(Integer.max(currentRP, Integer.min(2, currentStrength)), priestminrpcost);
 			u.commands.add(new Command("#rpcost", new Arg(currentRP)));
@@ -2783,6 +2573,129 @@ public class MageGenerator extends TroopGenerator {
 		
 		return m;
 	
+	}
+
+	private double randomizeLeadership(Unit u, double bonus, int tier)
+	{
+		double leaderrandom = this.random.nextDouble() + bonus;
+		double leadership = 0;
+		double adjustedLeadership = 0;
+		double minimumLeadership = 0;
+		
+		if (u.tags.containsName("priest"))
+			leaderrandom += 0.1;
+		
+		if (u.tags.containsName("warriormage"))
+		{	
+			//just max out the bonus for anything with warriormage
+			leaderrandom += 0.75;
+		}
+		else
+		{
+			if (tier > 1)
+			{
+				leaderrandom += 0.1;
+			
+				if (tier == 3)
+					leaderrandom += 0.1;
+			
+				//advanced priests are usually good leaders
+				if (u.tags.containsName("priest") && this.random.nextDouble() < 0.85)
+				{
+					leaderrandom += 0.55;
+					minimumLeadership = 40;
+				}
+			}
+			
+			//mages with leadership bonuses get an bigger than normal bonus
+			if (!u.tags.containsName("priest"))
+			{
+				if (tier == 3 || u.tags.containsName("#superior_leader") || u.tags.containsName("#good_leader"))
+					leaderrandom += 0.4;
+			}
+		}
+		
+		if (u.tags.containsName("#good_leader")) leaderrandom += 0.2;
+		if (u.tags.containsName("#superior_leader")) leaderrandom += 0.4;
+		
+		leaderrandom += bonus;
+		
+		//final leadership values are rounded to multiples of 5, but 10/40/80/120 thresholds are used to determine leadership level
+		if (leaderrandom > 1.75)
+			leadership = 120;
+		else if (leaderrandom > 1.7)
+			leadership = 81;
+		else if (leaderrandom > 1.55)
+			leadership = 80;
+		else if (leaderrandom > 1.5)
+			leadership = 61;
+		else if (leaderrandom > 1.4)
+			leadership = 60;
+		else if (leaderrandom > 1)
+			leadership = 40;
+		else if (leaderrandom > 0.9)
+			leadership = 39;
+		else if (leaderrandom > 0.1)
+			leadership = 10;
+		else
+			leadership = 0;
+		
+		
+		leadership = Math.max(leadership, minimumLeadership);
+		
+		
+		if (leadership > 80)
+		{
+			u.commands.add(new Command("#expertleader"));
+			adjustedLeadership = (Math.round(leadership / 5) * 5) - 120;
+		}
+		else if (leadership > 60)
+		{
+			u.commands.add(new Command("#goodleader"));
+			adjustedLeadership = (Math.round(leadership / 5) * 5) - 80;
+		}
+		else if (leadership > 10)
+		{
+			u.commands.add(new Command("#okayleader"));
+			adjustedLeadership = (Math.round(leadership / 5) * 5) - 40;
+		}
+		else if (leadership > 0)
+		{
+			u.commands.add(new Command("#poorleader"));
+			adjustedLeadership = (Math.round(leadership / 5) * 5) - 10;
+		}
+		else
+			u.commands.add(new Command("#noleader"));
+		
+		
+		double maximumCost = 50;
+		double cost = 0;
+		
+		cost = Math.round(leadership / 2);
+		
+		//priests and warriormages get a discount
+		if (u.tags.containsName("priest"))
+		{
+			//high leadership priests charge a higher premium than mages - probably because you already have enough reasons to recruit the mages?
+			maximumCost = 60;
+		
+			if (cost >= 20)
+				cost -= 10;
+			else
+				cost -= 5;
+		}
+		else if (u.tags.containsName("warriormage"))
+			cost -= 10;
+		
+		cost = Math.min(cost, maximumCost);
+		
+		if (adjustedLeadership != 0)
+			u.commands.add(Command.args("#command", Double.toString(adjustedLeadership)));
+		
+		if (cost != 0)
+			u.commands.add(Command.args("#gcost", "+" + Double.toString(cost)));
+		
+		return leadership;
 	}
 
 }


### PR DESCRIPTION
Mage/priest leadership was handled by large, arbitrary if/else trees that missed certain mages completely (and the part that had been split into its own method to handle special leadership was called twice for other mages instead.) Consolidated mage/priest leadership determination into a separate method instead. There are some minor nuances of the old generation method that are not captured but for the most part it's a fairly accurate approximation to what the original methods would have generated, but simplified and condensed. Could probably be expanded and generalized to encompass mundane commanders at some point.

Cleaned up a few other spots in MageGeneration.java but no functional changes beyond a very tiny tweak to extra mage chances.